### PR TITLE
Keep ivy archives as build artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,3 +26,9 @@ jobs:
       if: always()
       with:
         files: "*/target/*-reports/TEST*.xml"
+
+    - name: Keep build artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: ivy-archives
+        path: "**/*.iar"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,4 +31,6 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: ivy-archives
-        path: "**/*.iar"
+        path: |
+          **/*.iar
+          **/*.zip


### PR DESCRIPTION
Carefully review this. This will go to our template.

This will keep all generated ivy archives as build artifact. It will generate ONE zip.

![grafik](https://user-images.githubusercontent.com/7498380/142471186-bfcf36f9-1e2f-4728-8ea4-10ceecb088f9.png)

![grafik](https://user-images.githubusercontent.com/7498380/142471299-64ad0fc9-2515-4c10-be30-67f99ca55111.png)

I think we do not need to archive the release artifacts. Because they are available directly with the GitHub package system.

Just to mention: If we need a lot of storage - it costs:
https://docs.github.com/en/actions/learn-github-actions/usage-limits-billing-and-administration#artifact-and-log-retention-policy
