### PR TITLE
Reusable workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,4 +8,4 @@ on:
 
 jobs:
   build:
-    uses: axonivy-market/github-workflows/.github/workflows/ci.yml@master
+    uses: axonivy-market/github-workflows/.github/workflows/ci.yml@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,3 @@
-name: CI-Build
-
 on:
   push:
   schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,5 @@
+name: CI-Build
+
 on:
   push:
   schedule:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,28 +8,4 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Setup Java JDK
-      uses: actions/setup-java@v1.4.3
-      with:
-        java-version: 11
-
-    - name: Build with Maven
-      run: mvn clean verify --batch-mode
-
-    - name: Publish Unit Test Results
-      uses: EnricoMi/publish-unit-test-result-action@v1
-      if: always()
-      with:
-        files: "*/target/*-reports/TEST*.xml"
-
-    - name: Archive build artifact
-      uses: actions/upload-artifact@v2
-      with:
-        path: |
-          */target/*.iar
-          *product/target/*.zip
+    uses: axonivy-market/github-workflows/.github/workflows/ci.yml@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,36 +4,4 @@ on: workflow_dispatch
 
 jobs:
   build:
-    runs-on: ubuntu-latest
-
-    steps:
-    - uses: actions/checkout@v2
-
-    - name: Get branch name
-      id: branch-name
-      uses: tj-actions/branch-names@v4.5
-
-    - name: Setup Java JDK
-      uses: actions/setup-java@v1.4.3
-      with:
-        java-version: 11
-        server-id: github
-
-    - name: Configure Git
-      run: |
-        git config user.email "actions@github.com"
-        git config user.name "GitHub Actions"
-        git checkout -b new-release
-
-    - name: Build with Maven
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      run: mvn --batch-mode -Darguments='-DaltDeploymentRepository=github::https://maven.pkg.github.com/axonivy-market/excel-connector' release:prepare release:perform
-
-    - name: Create pull request
-      uses: repo-sync/pull-request@v2
-      with:
-        destination_branch: ${{ steps.branch-name.outputs.current_branch }}
-        source_branch: new-release
-        pr_title: "Release"
-        github_token: ${{ secrets.GITHUB_TOKEN }}
+    uses: axonivy-market/github-workflows/.github/workflows/release.yml@master

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,4 +4,4 @@ on: workflow_dispatch
 
 jobs:
   build:
-    uses: axonivy-market/github-workflows/.github/workflows/release.yml@master
+    uses: axonivy-market/github-workflows/.github/workflows/release.yml@v1


### PR DESCRIPTION
So here we have our reusable workflows:

https://github.com/axonivy-market/github-workflows

1) Do you like the repository name?
2) I've disabled tests (-Dmaven.test.skip=true) in release build. I think we don't need to execute tests when releasing.
3) At the moment I just refer to master branch (@master). I can refer to a specific commit, another branch or tag. What do you think. It is ok to refer to master. Or should we create a tag?
4) CI Build is triggered:

```
on:
  push:
  schedule:
    - cron:  '21 21 * * *'
  workflow_dispatch:
```
This will be still in every repo. I think push and workflow_dispatch is ok. But do we need cron? Because cron is automatically disabled after 60 days of repository inactivity.

